### PR TITLE
Update vite.config.js

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    middleware: [
+      (req, res, next) => {
+        res.setHeader('Access-Control-Allow-Origin', 'http://localhost:5173');
+        next();
+      }
+    ]
+  }
 })


### PR DESCRIPTION
# Added CORS Configuration to Vite Server

I have added a CORS (Cross-Origin Resource Sharing) configuration to the Vite server to allow requests from a specific origin.

## Changes Made

In the `vite.config.js` file, I added middleware to set the `Access-Control-Allow-Origin` header to `http://localhost:5173`.
